### PR TITLE
[feat] 카테고리 레이아웃 구현

### DIFF
--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -4,28 +4,33 @@ import Header from "@/components/layout/CategoryHeader";
 import FooterNav from "@/components/layout/CategoryFooterNav";
 import styled from 'styled-components';
 
-const TitleContainer = styled.div`
-  display: flex;
-  align-items: center;   /* 텍스트와 선을 수직 가운데로 정렬 */
-  margin-top: 16px;
-  padding: 0px 16px;
+
+interface TitleContainerProps {
+    $marginTop?: number;
+}
+
+// Transient props를 사용해 props가 DOM에 전달되지 않도록 설정
+const TitleContainer = styled.div<TitleContainerProps>`
+    display: flex;
+    align-items: center;
+    padding: 0px 16px;
+    margin-top: ${({ $marginTop = 16 }) => `${$marginTop}px`};  /* $marginTop을 CSS로 처리 */
 `;
 
 const Title = styled.div`
-  margin-right: 16px;     /* 텍스트와 선 사이의 간격 */
-  font-size: 20px;
-  font-weight: bold;
+    margin-right: 16px;     /* 텍스트와 선 사이의 간격 */
+    font-size: 20px;
+    font-weight: bold;
 `;
 
 const Line = styled.div`
-  flex-grow: 1;          /* 남은 공간을 채워서 선이 길게 늘어남 */
-  height: 1.2px;
-  background-color: #d9d9d9;
-  margin-right: 16px;
+    flex-grow: 1;          /* 남은 공간을 채워서 선이 길게 늘어남 */
+    height: 1.2px;
+    background-color: #d9d9d9;
 `;
 
 const ContentContainer = styled.div`
-  margin-top: 20px;
+    margin-top: 20px;
 `;
 
 const Subtitle = styled.div`
@@ -35,57 +40,92 @@ const Subtitle = styled.div`
 `;
 
 const Content = styled.div`
-  display: flex;
-  flex-direction: row;    /* 요소들을 가로로 나열 */
-  padding: 0 8px;         /* 좌우 패딩 8px 설정 */
-  gap: 8px;               /* 요소들 사이의 간격 8px 설정 */
-  overflow-x: auto;       /* 내용이 넘치면 가로 스크롤 생성 */
+    display: flex;
+    flex-direction: row;    /* 요소들을 가로로 나열 */
+    padding: 0 8px;         /* 좌우 패딩 8px 설정 */
+    gap: 8px;               /* 요소들 사이의 간격 8px 설정 */
+    overflow-x: auto;       /* 내용이 넘치면 가로 스크롤 생성 */
 `;
 
 const Item = styled.div`
-  padding: 8px;
-  border-radius: 4px;
-  flex-shrink: 0;        /* 아이템이 작아지지 않도록 설정 */
-  font-size: 14px;
+    padding: 8px;
+    border-radius: 4px;
+    flex-shrink: 0;        /* 아이템이 작아지지 않도록 설정 */
+    font-size: 14px;
 `;
 
 export default function Home() {
-  return (
-    <div className="page">
-      <Header />
-      <TitleContainer>
-        <Title>강아지</Title>
-        <Line />
-      </TitleContainer>
-      <ContentContainer>
-        <Subtitle>사료</Subtitle>
-        <Content>
-            <Item>전체</Item>
-            <Item>습식사료</Item>
-            <Item>소프트사료</Item>
-            <Item>건식사료</Item>
-        </Content>
-      </ContentContainer>
-      <ContentContainer>
-      <Subtitle>간식</Subtitle>
-        <Content>
-            <Item>전체</Item>
-            <Item>수제간식</Item>
-            <Item>빵/케이크</Item>
-            <Item>뼈간식</Item>
-            <Item>껌</Item>
-        </Content>
-      </ContentContainer>
-      <ContentContainer>
-      <Subtitle>용품</Subtitle>
-        <Content>
-            <Item>전체</Item>
-            <Item>위생용품</Item>
-            <Item>목욕용품</Item>
-            <Item>훈련용품</Item>
-        </Content>
-      </ContentContainer>
-      <FooterNav />
-    </div>
-  );
+    return (
+        <div className="page">
+            <Header />
+            {/* 강아지 섹션 */}
+            <TitleContainer $marginTop={16}>
+                <Title>강아지</Title>
+                <Line />
+            </TitleContainer>
+            <ContentContainer>
+                <Subtitle>사료</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>습식사료</Item>
+                    <Item>소프트사료</Item>
+                    <Item>건식사료</Item>
+                </Content>
+            </ContentContainer>
+            <ContentContainer>
+            <Subtitle>간식</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>수제간식</Item>
+                    <Item>빵/케이크</Item>
+                    <Item>뼈간식</Item>
+                    <Item>껌</Item>
+                </Content>
+            </ContentContainer>
+            <ContentContainer>
+            <Subtitle>용품</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>위생용품</Item>
+                    <Item>목욕용품</Item>
+                    <Item>훈련용품</Item>
+                </Content>
+            </ContentContainer>
+
+            {/* 고양이 섹션 */}
+            <TitleContainer $marginTop={20}>
+                <Title>고양이</Title>
+                <Line />
+            </TitleContainer>
+            <ContentContainer>
+                <Subtitle>사료</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>캔/통조림</Item>
+                    <Item>건식사료</Item>
+                    <Item>습식사료</Item>
+                    <Item>에어/동결사료</Item>
+                </Content>
+            </ContentContainer>
+            <ContentContainer>
+            <Subtitle>간식</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>파우치/츄르</Item>
+                    <Item>수제간식</Item>
+                    <Item>캣닢/캣그라스</Item>
+                </Content>
+            </ContentContainer>
+            <ContentContainer>
+            <Subtitle>용품</Subtitle>
+                <Content>
+                    <Item>전체</Item>
+                    <Item>캣타워</Item>
+                    <Item>급수기</Item>
+                    <Item>목욕용품</Item>
+                </Content>
+            </ContentContainer>
+            <FooterNav />
+        </div>
+    );
 }

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -13,6 +13,7 @@ interface TitleContainerProps {
 const ContentWrapper = styled.div`
     flex-grow: 1;
     padding-bottom: 100px;  /* 임시로 푸터 높이만큼 하단 여백 추가 */
+    padding-top: 60px;
 `;
 
 // Transient props를 사용해 props가 DOM에 전달되지 않도록 설정

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -3,6 +3,7 @@
 import Header from "@/components/layout/CategoryHeader";
 import FooterNav from "@/components/layout/CategoryFooterNav";
 import styled from 'styled-components';
+import Link from "next/link";
 
 
 interface TitleContainerProps {
@@ -52,11 +53,17 @@ const Content = styled.div`
     overflow-x: auto;       /* 내용이 넘치면 가로 스크롤 생성 */
 `;
 
-const Item = styled.div`
+const Item = styled(Link)`  /* Link로 Item을 클릭 가능하게 만듦 */
     padding: 8px;
-    border-radius: 4px;
-    flex-shrink: 0;        /* 아이템이 작아지지 않도록 설정 */
+    border-radius: 30px;
+    flex-shrink: 0;
     font-size: 14px;
+    text-decoration: none;    /* 링크의 기본 스타일을 없앰 */
+    color: black;
+    display: inline-block;
+    &:hover {
+        background-color: #F5A48F; /* Hover 효과 추가 */
+    }
 `;
 
 export default function Home() {
@@ -72,29 +79,29 @@ export default function Home() {
             <ContentContainer>
                 <Subtitle>사료</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>습식사료</Item>
-                    <Item>소프트사료</Item>
-                    <Item>건식사료</Item>
+                    <Item href="/dog/food">전체</Item>
+                    <Item href="/dog/wet-food">습식사료</Item>
+                    <Item href="/dog/soft-food">소프트사료</Item>
+                    <Item href="/dog/dry-food">건식사료</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>간식</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>수제간식</Item>
-                    <Item>빵/케이크</Item>
-                    <Item>뼈간식</Item>
-                    <Item>껌</Item>
+                    <Item href="/dog/food">전체</Item>
+                    <Item href="/dog/food">수제간식</Item>
+                    <Item href="/dog/food">빵/케이크</Item>
+                    <Item href="/dog/food">뼈간식</Item>
+                    <Item href="/dog/food">껌</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>용품</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>위생용품</Item>
-                    <Item>목욕용품</Item>
-                    <Item>훈련용품</Item>
+                    <Item href="/dog/food">전체</Item>
+                    <Item href="/dog/food">위생용품</Item>
+                    <Item href="/dog/food">목욕용품</Item>
+                    <Item href="/dog/food">훈련용품</Item>
                 </Content>
             </ContentContainer>
 
@@ -106,29 +113,29 @@ export default function Home() {
             <ContentContainer>
                 <Subtitle>사료</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>캔/통조림</Item>
-                    <Item>건식사료</Item>
-                    <Item>습식사료</Item>
-                    <Item>에어/동결사료</Item>
+                    <Item href="/cat/food">전체</Item>
+                    <Item href="/cat/food">캔/통조림</Item>
+                    <Item href="/cat/food">건식사료</Item>
+                    <Item href="/cat/food">습식사료</Item>
+                    <Item href="/cat/food">에어/동결사료</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>간식</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>파우치/츄르</Item>
-                    <Item>수제간식</Item>
-                    <Item>캣닢/캣그라스</Item>
+                    <Item href="/cat/food">전체</Item>
+                    <Item href="/cat/food">파우치/츄르</Item>
+                    <Item href="/cat/food">수제간식</Item>
+                    <Item href="/cat/food">캣닢/캣그라스</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>용품</Subtitle>
                 <Content>
-                    <Item>전체</Item>
-                    <Item>캣타워</Item>
-                    <Item>급수기</Item>
-                    <Item>목욕용품</Item>
+                    <Item href="/cat/food">전체</Item>
+                    <Item href="/cat/food">캣타워</Item>
+                    <Item href="/cat/food">급수기</Item>
+                    <Item href="/cat/food">목욕용품</Item>
                 </Content>
             </ContentContainer>
             </ContentWrapper>

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -63,7 +63,7 @@ const Item = styled(Link)`  /* Link로 Item을 클릭 가능하게 만듦 */
     color: black;
     display: inline-block;
     &:hover {
-        background-color: #F5A48F; /* Hover 효과 추가 */
+        background-color: #F5A48F;
     }
 `;
 

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -31,7 +31,7 @@ const Title = styled.div`
 
 const Line = styled.div`
     flex-grow: 1;          /* 남은 공간을 채워서 선이 길게 늘어남 */
-    height: 1.2px;
+    height: 1px;
     background-color: #d9d9d9;
 `;
 

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -9,16 +9,21 @@ interface TitleContainerProps {
     $marginTop?: number;
 }
 
+const ContentWrapper = styled.div`
+    flex-grow: 1;
+    padding-bottom: 100px;  /* 임시로 푸터 높이만큼 하단 여백 추가 */
+`;
+
 // Transient props를 사용해 props가 DOM에 전달되지 않도록 설정
 const TitleContainer = styled.div<TitleContainerProps>`
     display: flex;
     align-items: center;
     padding: 0px 16px;
-    margin-top: ${({ $marginTop = 16 }) => `${$marginTop}px`};  /* $marginTop을 CSS로 처리 */
+    margin-top: ${({ $marginTop = 16 }) => `${$marginTop}px`};
 `;
 
 const Title = styled.div`
-    margin-right: 16px;     /* 텍스트와 선 사이의 간격 */
+    margin-right: 16px;
     font-size: 20px;
     font-weight: bold;
 `;
@@ -42,7 +47,7 @@ const Subtitle = styled.div`
 const Content = styled.div`
     display: flex;
     flex-direction: row;    /* 요소들을 가로로 나열 */
-    padding: 0 8px;         /* 좌우 패딩 8px 설정 */
+    padding: 0 8px;         
     gap: 8px;               /* 요소들 사이의 간격 8px 설정 */
     overflow-x: auto;       /* 내용이 넘치면 가로 스크롤 생성 */
 `;
@@ -58,6 +63,7 @@ export default function Home() {
     return (
         <div className="page">
             <Header />
+            <ContentWrapper>
             {/* 강아지 섹션 */}
             <TitleContainer $marginTop={16}>
                 <Title>강아지</Title>
@@ -125,6 +131,7 @@ export default function Home() {
                     <Item>목욕용품</Item>
                 </Content>
             </ContentContainer>
+            </ContentWrapper>
             <FooterNav />
         </div>
     );

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Header from "@/components/layout/CategoryHeader";
+import FooterNav from "@/components/layout/CategoryFooterNav";
+import styled from 'styled-components';
+
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;   /* 텍스트와 선을 수직 가운데로 정렬 */
+  margin-top: 16px;
+  padding: 0px 16px;
+`;
+
+const Title = styled.div`
+  font-size: 20px;
+  margin-right: 16px;     /* 텍스트와 선 사이의 간격 */
+`;
+
+const Line = styled.div`
+  flex-grow: 1;          /* 남은 공간을 채워서 선이 길게 늘어남 */
+  height: 1.2px;           /* 선의 두께 */
+  background-color: #d9d9d9; /* 선의 색상 (여기서는 검정색) */
+  margin-right: 16px;
+`;
+
+const ContentContainer = styled.div`
+  margin-top: 20px;
+`;
+
+const Subtitle = styled.div`
+    padding: 16px;
+    font-size: 16px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: row;    /* 요소들을 가로로 나열 */
+  padding: 0 8px;         /* 좌우 패딩 8px 설정 */
+  gap: 8px;               /* 요소들 사이의 간격 8px 설정 */
+  overflow-x: auto;       /* 내용이 넘치면 가로 스크롤 생성 */
+`;
+
+const Item = styled.div`
+  padding: 8px;
+  border-radius: 4px;
+  flex-shrink: 0;        /* 아이템이 작아지지 않도록 설정 */
+  font-size: 14px;
+`;
+
+export default function Home() {
+  return (
+    <div className="page">
+      <Header />
+      <TitleContainer>
+        <Title>강아지</Title>
+        <Line />
+      </TitleContainer>
+      <ContentContainer>
+        <Subtitle>사료</Subtitle>
+        <Content>
+            <Item>전체</Item>
+            <Item>습식사료</Item>
+            <Item>소프트사료</Item>
+            <Item>건식사료</Item>
+        </Content>
+      </ContentContainer>
+      <FooterNav />
+    </div>
+  );
+}

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -12,14 +12,15 @@ const TitleContainer = styled.div`
 `;
 
 const Title = styled.div`
-  font-size: 20px;
   margin-right: 16px;     /* 텍스트와 선 사이의 간격 */
+  font-size: 20px;
+  font-weight: bold;
 `;
 
 const Line = styled.div`
   flex-grow: 1;          /* 남은 공간을 채워서 선이 길게 늘어남 */
-  height: 1.2px;           /* 선의 두께 */
-  background-color: #d9d9d9; /* 선의 색상 (여기서는 검정색) */
+  height: 1.2px;
+  background-color: #d9d9d9;
   margin-right: 16px;
 `;
 
@@ -30,6 +31,7 @@ const ContentContainer = styled.div`
 const Subtitle = styled.div`
     padding: 16px;
     font-size: 16px;
+    font-weight: bold;
 `;
 
 const Content = styled.div`
@@ -62,6 +64,25 @@ export default function Home() {
             <Item>습식사료</Item>
             <Item>소프트사료</Item>
             <Item>건식사료</Item>
+        </Content>
+      </ContentContainer>
+      <ContentContainer>
+      <Subtitle>간식</Subtitle>
+        <Content>
+            <Item>전체</Item>
+            <Item>수제간식</Item>
+            <Item>빵/케이크</Item>
+            <Item>뼈간식</Item>
+            <Item>껌</Item>
+        </Content>
+      </ContentContainer>
+      <ContentContainer>
+      <Subtitle>용품</Subtitle>
+        <Content>
+            <Item>전체</Item>
+            <Item>위생용품</Item>
+            <Item>목욕용품</Item>
+            <Item>훈련용품</Item>
         </Content>
       </ContentContainer>
       <FooterNav />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,16 @@
+/* globals.css */
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url(./fonts/PretendardVariable.woff2) format('opentype');
+}
+
 :root {
-  --background-color: gray;
-  --text-color: #171717;
+  --background-color: white;
+  --content-background-color: #F8F8F8;
   max-width: 600px;
+  font-family: 'Pretendard', sans-serif;
+  margin: 0 auto;
 }
 
 html, body {
@@ -13,16 +22,16 @@ html, body {
 body {
   background-color: var(--background-color);
   color: var(--text-color);
+  max-width: inherit;
   margin: 0;
   padding: 0;
 }
 
 .page {
-  position: relative;
+  background-color: var(--content-background-color);
+  width: 100%;
+  max-width: inherit;
   min-height: 100%;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url(./fonts/PretendardVariable.woff2) format('opentype');
+  margin: 0 auto;
+  position: relative;
 }

--- a/src/components/layout/CategoryFooterNav.tsx
+++ b/src/components/layout/CategoryFooterNav.tsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import HamburgerSvg from '../../../public/svgs/hamburger_icon_select.svg';
-import MyDongleSvg from '../../../public/svgs/mydongle_icon.svg';
-import DogHomeSvg from '../../../public/svgs/home_icon.svg';
-import BasketSvg from '../../../public/svgs/basket_icon.svg';
-import MySvg from '../../../public/svgs/user_icon.svg';
+import HamburgerSvg from '/public/svgs/hamburger_icon_select.svg';
+import MyDongleSvg from '/public/svgs/mydongle_icon.svg';
+import DogHomeSvg from '/public/svgs/home_icon.svg';
+import BasketSvg from '/public/svgs/basket_icon.svg';
+import MySvg from '/public/svgs/user_icon.svg';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -53,7 +53,7 @@ const BoldText = styled.span`
     font-size: 12px;
     color: black;
     text-align: center;
-    font-weight: bold;
+    font-weight: 600;
 `;
 
 const CategoryFooterNav = () => {

--- a/src/components/layout/CategoryHeader.tsx
+++ b/src/components/layout/CategoryHeader.tsx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import DongleSvg from '../../../public/svgs/blacklogo_dongle.svg'
-import DogSvg from '../../../public/svgs/logo_dog.svg';
-import ShoppingBasketSvg from '../../../public/svgs/black_shoppingbag.svg';
+import DongleSvg from '/public/svgs/blacklogo_dongle.svg'
+import DogSvg from '/public/svgs/logo_dog.svg';
+import ShoppingBasketSvg from '/public/svgs/black_shoppingbag.svg';
 
 const Wrapper = styled.div`
   padding: 14px 16px;

--- a/src/components/layout/CategoryHeader.tsx
+++ b/src/components/layout/CategoryHeader.tsx
@@ -8,8 +8,15 @@ import DogSvg from '../../../public/svgs/logo_dog.svg';
 import ShoppingBasketSvg from '../../../public/svgs/black_shoppingbag.svg';
 
 const Wrapper = styled.div`
-  padding: 16px 14px;
+  padding: 14px 16px;
+  position: fixed;    /* 헤더를 상단에 고정 */
+  width: 100%;
+  top: 0;
+  max-width: inherit;
+  box-sizing: border-box;
+  background-color: #f8f8f8;
 `;
+
 const LogoContainer = styled.div`
   display: flex;
   gap: 2px

--- a/src/components/layout/MainFooterNav.tsx
+++ b/src/components/layout/MainFooterNav.tsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import HamburgerSvg from '../../../public/svgs/hamburger_icon.svg';
-import MyDongleSvg from '../../../public/svgs/mydongle_icon.svg';
-import DogHomeSvg from '../../../public/svgs/home_icon_select.svg';
-import BasketSvg from '../../../public/svgs/basket_icon.svg';
-import MySvg from '../../../public/svgs/user_icon.svg';
+import HamburgerSvg from '/public/svgs/hamburger_icon.svg';
+import MyDongleSvg from '/public/svgs/mydongle_icon.svg';
+import DogHomeSvg from '/public/svgs/home_icon_select.svg';
+import BasketSvg from '/public/svgs/basket_icon.svg';
+import MySvg from '/public/svgs/user_icon.svg';
 
 const FooterNavContainer = styled.nav`
   position: fixed;

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import DongleSvg from '../../../public/svgs/whitelogo_dongle.svg'
-import DogSvg from '../../../public/svgs/logo_dog.svg';
-import ShoppingBasketSvg from '../../../public/svgs/white_shoppingbag.svg';
+import DongleSvg from '/public/svgs/whitelogo_dongle.svg'
+import DogSvg from '/public/svgs/logo_dog.svg';
+import ShoppingBasketSvg from '/public/svgs/white_shoppingbag.svg';
 
 const Wrapper = styled.div`
   padding: 16px 14px;

--- a/src/components/layout/MyDongleFooterNav.tsx
+++ b/src/components/layout/MyDongleFooterNav.tsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import HamburgerSvg from '../../../public/svgs/hamburger_icon.svg';
-import MyDongleSvg from '../../../public/svgs/mydongle_icon_select.svg';
-import DogHomeSvg from '../../../public/svgs/home_icon.svg';
-import BasketSvg from '../../../public/svgs/basket_icon.svg';
-import MySvg from '../../../public/svgs/user_icon.svg';
+import HamburgerSvg from '/public/svgs/hamburger_icon.svg';
+import MyDongleSvg from '/public/svgs/mydongle_icon_select.svg';
+import DogHomeSvg from '/public/svgs/home_icon.svg';
+import BasketSvg from '/public/svgs/basket_icon.svg';
+import MySvg from '/public/svgs/user_icon.svg';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -53,7 +53,7 @@ const BoldText = styled.span`
     font-size: 12px;
     color: black;
     text-align: center;
-    font-weight: bold;
+    font-weight: 600;
 `;
 
 const MyDongleFooterNav = () => {

--- a/src/components/layout/MyMarketFooterNav.tsx
+++ b/src/components/layout/MyMarketFooterNav.tsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import HamburgerSvg from '../../../public/svgs/hamburger_icon.svg';
-import MyDongleSvg from '../../../public/svgs/mydongle_icon.svg';
-import DogHomeSvg from '../../../public/svgs/home_icon.svg';
-import BasketSvg from '../../../public/svgs/basket_icon_select.svg';
-import MySvg from '../../../public/svgs/user_icon.svg';
+import HamburgerSvg from '/public/svgs/hamburger_icon.svg';
+import MyDongleSvg from '/public/svgs/mydongle_icon.svg';
+import DogHomeSvg from '/public/svgs/home_icon.svg';
+import BasketSvg from '/public/svgs/basket_icon_select.svg';
+import MySvg from '/public/svgs/user_icon.svg';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -53,7 +53,7 @@ const BoldText = styled.span`
     font-size: 12px;
     color: black;
     text-align: center;
-    font-weight: bold;
+    font-weight: 600;
 `;
 
 const MyMarketFooterNav = () => {

--- a/src/components/layout/UserInfoFooterNav.tsx
+++ b/src/components/layout/UserInfoFooterNav.tsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import HamburgerSvg from '../../../public/svgs/hamburger_icon.svg';
-import MyDongleSvg from '../../../public/svgs/mydongle_icon.svg';
-import DogHomeSvg from '../../../public/svgs/home_icon.svg';
-import BasketSvg from '../../../public/svgs/basket_icon.svg';
-import MySvg from '../../../public/svgs/user_icon_select.svg';
+import HamburgerSvg from '/public/svgs/hamburger_icon.svg';
+import MyDongleSvg from '/public/svgs/mydongle_icon.svg';
+import DogHomeSvg from '/public/svgs/home_icon.svg';
+import BasketSvg from '/public/svgs/basket_icon.svg';
+import MySvg from '/public/svgs/user_icon_select.svg';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -53,7 +53,7 @@ const BoldText = styled.span`
     font-size: 12px;
     color: black;
     text-align: center;
-    font-weight: bold;
+    font-weight: 600;
 `;
 
 const UserInfoFooterNav = () => {


### PR DESCRIPTION
## 관련 이슈

- #4 

## 요약 📝

- 카테고리 레이아웃 구현

## 상세 내용 및 스크린샷 🔥

- 
<img src="https://github.com/user-attachments/assets/84df5da5-f434-4035-9364-97cc745a8d3d" width="200px" />
<img src="https://github.com/user-attachments/assets/57f7e85a-0449-4112-a0c9-5bb412f44a8f" width="200px" />

## 리뷰어에게 부탁, 유의사항 🙏

- 카테고리 레이아웃 구현 하였습니다.
웹에서는 item hover시 메인 색상 나오고, 모바일에서는 item 클릭 시 메인 색상 나오도록 설정하였습니다.
