### PR TITLE
Fix#20 카테고리 상품 상세 리스트 픽스

### DIFF
--- a/src/components/header/CategoryDetailHeader.tsx
+++ b/src/components/header/CategoryDetailHeader.tsx
@@ -7,34 +7,36 @@ import BackSvg from '/public/svgs/header/back_arrow.svg'
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
 
 const Wrapper = styled.div`
-  padding: 16px 14px;
+  position: fixed;
+  display: flex;
+  padding: 14px 16px;
+  width: 100%;
+  height: 60px;
+  align-items: center;
+  justify-content: space-between;
+  top: 0;
+  max-width: inherit;
+  box-sizing: border-box;
+  background-color: #f8f8f8;
+  z-index: 1000;
 `;
 
 const Title = styled.div`
-    font-weight: 600;
-`;
-
-const LogoWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  font-weight: 600;
 `;
 
 interface CategoryDetailHeaderProps {
   title: string;
 }
 
-const CategoryDetailHeader : React.FC<CategoryDetailHeaderProps> = ({ title }) => {
+const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title }) => {
   return (
     <Wrapper>
-      <LogoWrapper>
-          <BackSvg />
-          <Title>{title}</Title>
-        <ShoppingBasketSvg />
-      </LogoWrapper>      
+      <BackSvg />
+      <Title>{title}</Title>
+      <ShoppingBasketSvg />
     </Wrapper>
   );
 }
-
 
 export default CategoryDetailHeader;

--- a/src/components/header/CategoryDetailHeader.tsx
+++ b/src/components/header/CategoryDetailHeader.tsx
@@ -3,7 +3,8 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import BackSvg from '/public/svgs/header/back_arrow.svg'
+import { useRouter } from 'next/navigation'; // useRouter를 import
+import BackSvg from '/public/svgs/header/back_arrow.svg';
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
 
 const Wrapper = styled.div`
@@ -30,11 +31,21 @@ interface CategoryDetailHeaderProps {
 }
 
 const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title }) => {
+  const router = useRouter();
+
+  const handleBackClick = () => {
+    router.back(); // 이전 페이지로 이동
+  };
+
+  const handleCartClick = () => {
+    router.push('/mymarket/cart');
+  };
+
   return (
     <Wrapper>
-      <BackSvg />
+      <BackSvg onClick={handleBackClick} style={{ cursor: 'pointer' }} />
       <Title>{title}</Title>
-      <ShoppingBasketSvg />
+      <ShoppingBasketSvg onClick={handleCartClick} style={{ cursor: 'pointer' }} />
     </Wrapper>
   );
 }

--- a/src/components/header/SelectBox.tsx
+++ b/src/components/header/SelectBox.tsx
@@ -9,24 +9,43 @@ const SelectBoxContainer = styled.div`
   border: 1px solid gray;
   border-radius: 30px;
   position: relative;
+  cursor: pointer;
 `;
 
-const Select = styled.select<{ $width: number }>`
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  border: none;
-  background: transparent;
+const SelectedOption = styled.div<{ $width: number }>`
   font-size: 12px;
-  cursor: pointer;
   color: black;
-  outline: none;
   width: ${({ $width }) => `${$width}px`};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const Arrow = styled.div`
   display: flex;
   cursor: pointer;
+`;
+
+const Dropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  background: white;
+  border: 1px solid gray;
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+`;
+
+const Option = styled.div`
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  &:hover {
+    background-color: #f0f0f0;
+  }
 `;
 
 interface SelectBoxProps {
@@ -36,38 +55,40 @@ interface SelectBoxProps {
 }
 
 export default function SelectBox({ options, selectedOption, onChange }: SelectBoxProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const [selectWidth, setSelectWidth] = useState(50);
   const tempSpanRef = useRef<HTMLSpanElement>(null);
-  const selectRef = useRef<HTMLSelectElement>(null);
 
+  // 선택된 옵션의 너비를 동적으로 설정
   useEffect(() => {
     if (tempSpanRef.current) {
       tempSpanRef.current.innerText = selectedOption;
-      setSelectWidth(tempSpanRef.current.offsetWidth + 12);
+      setSelectWidth(tempSpanRef.current.offsetWidth + 12); // 추가 padding 여유를 위해 +12
     }
   }, [selectedOption]);
 
-  const handleArrowClick = () => {
-    selectRef.current?.focus();
+  const handleOptionClick = (option: string) => {
+    onChange(option);
+    setIsOpen(false);
   };
 
+  const toggleDropdown = () => setIsOpen(!isOpen);
+
   return (
-    <SelectBoxContainer>
-      <Select
-        ref={selectRef}
-        $width={selectWidth}
-        value={selectedOption}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        {options.map(option => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </Select>
-      <Arrow onClick={handleArrowClick}>
+    <SelectBoxContainer onClick={toggleDropdown}>
+      <SelectedOption $width={selectWidth}>{selectedOption}</SelectedOption>
+      <Arrow>
         <ArrowSvg />
       </Arrow>
+      {isOpen && (
+        <Dropdown>
+          {options.map((option) => (
+            <Option key={option} onClick={() => handleOptionClick(option)}>
+              {option}
+            </Option>
+          ))}
+        </Dropdown>
+      )}
       <span ref={tempSpanRef} style={{ visibility: 'hidden', position: 'absolute', fontSize: '12px', whiteSpace: 'pre' }} />
     </SelectBoxContainer>
   );

--- a/src/components/navbar/CategoryFooterNav.tsx
+++ b/src/components/navbar/CategoryFooterNav.tsx
@@ -8,6 +8,7 @@ import MyDongleSvg from '/public/svgs/navbar/mydongle_icon.svg';
 import DogHomeSvg from '/public/svgs/navbar/home_icon.svg';
 import BasketSvg from '/public/svgs/navbar/basket_icon.svg';
 import MySvg from '/public/svgs/navbar/user_icon.svg';
+import Link from 'next/link';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -37,7 +38,7 @@ const NavContainer = styled.div`
     width: 100%;
 `;
 
-const IconContainer = styled.div`
+const IconContainer = styled(Link)`
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -45,6 +46,7 @@ const IconContainer = styled.div`
     font-size: 12px;
     color: black;
     text-align: center;
+    text-decoration: none;
     align-items: center;
 `;
 
@@ -60,23 +62,23 @@ const CategoryFooterNav = () => {
   return (
     <FooterNavContainer>
       <NavContainer>
-        <IconContainer>
+        <IconContainer href="/category">
             <HamburgerSvg />
             <BoldText>카테고리</BoldText>
         </IconContainer>
-        <IconContainer>
+        <IconContainer href="/mydongle">
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>
-        <IconContainer>
+        <IconContainer href="/dog">
             <DogHomeSvg />
             <span>동글 홈</span>
         </IconContainer>
-        <IconContainer>
+        <IconContainer href="/mymarket/wishlist">
             <BasketSvg />
             <span>마이 마켓</span>
         </IconContainer>
-        <IconContainer>
+        <IconContainer href="/profile">
             <MySvg />
             <span>내 정보</span>
         </IconContainer>

--- a/src/pages/category/food.tsx
+++ b/src/pages/category/food.tsx
@@ -8,10 +8,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
-  padding-bottom: 100px;
-`;
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -109,7 +105,7 @@ export default function FoodPage() {
   return (
     <div className="page">
       <Header title={"사료"} />
-      <Wrapper>
+      <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>
           {categoryOptions.map(option => (
@@ -141,7 +137,7 @@ export default function FoodPage() {
             <ProductRow key={index} items={rowProducts} />
           ))}
         </ProductListContainer>
-      </Wrapper>
+      </div>
       <FooterNav />
     </div>
   );

--- a/src/pages/category/goods.tsx
+++ b/src/pages/category/goods.tsx
@@ -8,10 +8,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-const Wraaper = styled.div`
-    padding-bottom: 100px;
-`;
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -109,7 +105,7 @@ export default function FoodPage() {
   return (
     <div className="page">
       <Header title={"용품"}/>
-      <Wraaper>
+      <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>
             {categoryOptions.map(option => (
@@ -141,7 +137,7 @@ export default function FoodPage() {
             <ProductRow key={index} items={rowProducts} />
             ))}
         </ProductListContainer>
-      </Wraaper>
+      </div>
       <FooterNav />
     </div>
   );

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -74,29 +74,29 @@ export default function Home() {
             <ContentContainer>
                 <Subtitle>사료</Subtitle>
                 <Content>
-                    <Item href="/dog/food">전체</Item>
-                    <Item href="/dog/wet-food">습식사료</Item>
-                    <Item href="/dog/soft-food">소프트사료</Item>
-                    <Item href="/dog/dry-food">건식사료</Item>
+                    <Item href="/category/food">전체</Item>
+                    <Item href="/category/food">습식사료</Item>
+                    <Item href="/category/food">소프트사료</Item>
+                    <Item href="/category/food">건식사료</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>간식</Subtitle>
                 <Content>
-                    <Item href="/dog/food">전체</Item>
-                    <Item href="/dog/food">수제간식</Item>
-                    <Item href="/dog/food">빵/케이크</Item>
-                    <Item href="/dog/food">뼈간식</Item>
-                    <Item href="/dog/food">껌</Item>
+                    <Item href="/category/snack">전체</Item>
+                    <Item href="/category/snack">수제간식</Item>
+                    <Item href="/category/snack">빵/케이크</Item>
+                    <Item href="/category/snack">뼈간식</Item>
+                    <Item href="/category/snack">껌</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>용품</Subtitle>
                 <Content>
-                    <Item href="/dog/food">전체</Item>
-                    <Item href="/dog/food">위생용품</Item>
-                    <Item href="/dog/food">목욕용품</Item>
-                    <Item href="/dog/food">훈련용품</Item>
+                    <Item href="/category/goods">전체</Item>
+                    <Item href="/category/goods">위생용품</Item>
+                    <Item href="/category/goods">목욕용품</Item>
+                    <Item href="/category/goods">훈련용품</Item>
                 </Content>
             </ContentContainer>
 
@@ -108,29 +108,29 @@ export default function Home() {
             <ContentContainer>
                 <Subtitle>사료</Subtitle>
                 <Content>
-                    <Item href="/cat/food">전체</Item>
-                    <Item href="/cat/food">캔/통조림</Item>
-                    <Item href="/cat/food">건식사료</Item>
-                    <Item href="/cat/food">습식사료</Item>
-                    <Item href="/cat/food">에어/동결사료</Item>
+                    <Item href="/category/food">전체</Item>
+                    <Item href="/category/food">캔/통조림</Item>
+                    <Item href="/category/food">건식사료</Item>
+                    <Item href="/category/food">습식사료</Item>
+                    <Item href="/category/food">에어/동결사료</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>간식</Subtitle>
                 <Content>
-                    <Item href="/cat/food">전체</Item>
-                    <Item href="/cat/food">파우치/츄르</Item>
-                    <Item href="/cat/food">수제간식</Item>
-                    <Item href="/cat/food">캣닢/캣그라스</Item>
+                    <Item href="/category/snack">전체</Item>
+                    <Item href="/category/snack">파우치/츄르</Item>
+                    <Item href="/category/snack">수제간식</Item>
+                    <Item href="/category/snack">캣닢/캣그라스</Item>
                 </Content>
             </ContentContainer>
             <ContentContainer>
             <Subtitle>용품</Subtitle>
                 <Content>
-                    <Item href="/cat/food">전체</Item>
-                    <Item href="/cat/food">캣타워</Item>
-                    <Item href="/cat/food">급수기</Item>
-                    <Item href="/cat/food">목욕용품</Item>
+                    <Item href="/category/goods">전체</Item>
+                    <Item href="/category/goods">캣타워</Item>
+                    <Item href="/category/goods">급수기</Item>
+                    <Item href="/category/goods">목욕용품</Item>
                 </Content>
             </ContentContainer>
             </div>

--- a/src/pages/category/snack.tsx
+++ b/src/pages/category/snack.tsx
@@ -8,10 +8,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
-  padding-bottom: 100px;
-`;
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -109,7 +105,7 @@ export default function FoodPage() {
   return (
     <div className="page">
       <Header title={"간식"}/>
-      <Wrapper>
+      <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>
             {categoryOptions.map(option => (
@@ -141,7 +137,7 @@ export default function FoodPage() {
             <ProductRow key={index} items={rowProducts} />
             ))}
         </ProductListContainer>
-      </Wrapper>
+      </div>
       <FooterNav />
     </div>
   );


### PR DESCRIPTION
## 관련 이슈

- 카테고리 상품 상세 리스트 픽스

## 요약 📝

- 상품 상세 리스트의 푸터, 헤더 라우터 설정 (임시경로 포함)
- 카테고리 페이지에서의 라우터 설정 (사료/간식/용품 경로로 설정)
- 필터링 selectbox 아래화살표svg 클릭시에도 dropdown 되도록 수정

## 상세 내용 및 스크린샷 🔥
-
<img src="https://github.com/user-attachments/assets/31e35edd-c302-41d3-b7ee-081af99d6edb" width="200px" />
<img src="https://github.com/user-attachments/assets/84b2c94a-111b-4973-b33e-370c09ada91a" width="200px" />
<img src="https://github.com/user-attachments/assets/af2aae62-82ed-418e-a3d7-699ad68327fd" width="200px" />

## 리뷰어에게 부탁, 유의사항 🙏

- 커밋 메시지 중간에 [feat]도 포함이 되어있어요 !
