### PR TITLE
[feat] 카테고리&아이템: 디테일 수정

### DIFF
--- a/src/components/header/CategoryDetailHeader.tsx
+++ b/src/components/header/CategoryDetailHeader.tsx
@@ -26,15 +26,36 @@ const Title = styled.div`
   font-weight: 600;
 `;
 
+const BasketContainer = styled.div`
+  position: relative;
+`;
+
+const ItemCountBadge = styled.span`
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  background-color: #E55737;
+  color: white;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+`;
+
 interface CategoryDetailHeaderProps {
   title: string;
+  itemCount: number;
 }
 
-const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title }) => {
+const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title, itemCount }) => {
   const router = useRouter();
+  const history = useRouter();
 
   const handleBackClick = () => {
-    router.back(); // 이전 페이지로 이동
+    history.back();
   };
 
   const handleCartClick = () => {
@@ -45,7 +66,10 @@ const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title }) =>
     <Wrapper>
       <BackSvg onClick={handleBackClick} style={{ cursor: 'pointer' }} />
       <Title>{title}</Title>
-      <ShoppingBasketSvg onClick={handleCartClick} style={{ cursor: 'pointer' }} />
+      <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
+          <ShoppingBasketSvg />
+          {itemCount > 0 && <ItemCountBadge>{itemCount}</ItemCountBadge>}
+        </BasketContainer>
     </Wrapper>
   );
 }

--- a/src/components/header/ItemHeader.tsx
+++ b/src/components/header/ItemHeader.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 import BackSvg from '/public/svgs/header/back_arrow.svg'
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
+import router, { useRouter } from 'next/router';
 
 const Wrapper = styled.div`
   padding: 14px 16px;
@@ -28,15 +29,52 @@ const LogoWrapper = styled.div`
   justify-content: space-between;
 `;
 
-const ItemHeader = () => {
+const BasketContainer = styled.div`
+  position: relative;
+`;
+
+const ItemCountBadge = styled.span`
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  background-color: #E55737;
+  color: white;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+`;
+
+interface CategoryHeaderProps {
+  itemCount: number;
+}
+
+const ItemHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
+  const router = useRouter();
+  const history = useRouter();
+
+  const handleBackClick = () => {
+    history.back();
+  };
+
+  const handleCartClick = () => {
+    router.push('/mymarket/cart');
+  };
+  
   return (
     <Wrapper>
       <LogoWrapper>
-        <LogoContainer>
+        <LogoContainer onClick={handleBackClick} style={{ cursor: 'pointer' }}>
           <BackSvg />
         </LogoContainer>
-        <ShoppingBasketSvg />
-      </LogoWrapper>      
+        <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
+          <ShoppingBasketSvg />
+          {itemCount > 0 && <ItemCountBadge>{itemCount}</ItemCountBadge>}
+        </BasketContainer>
+      </LogoWrapper>
     </Wrapper>
   );
 }

--- a/src/components/items/MainItem.tsx
+++ b/src/components/items/MainItem.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 const ItemContainer = styled.div`
     display: flex;
     flex-direction: column;
+    cursor: pointer;
 `;
 
 const Image = styled.img`

--- a/src/components/navbar/ItemFooter.tsx
+++ b/src/components/navbar/ItemFooter.tsx
@@ -8,6 +8,7 @@ import HeartSvg from '/public/svgs/element/heart.svg';
 import HeartFullSvg from '/public/svgs/element/heart_full.svg';
 import PlusSvg from '/public/svgs/element/plus.svg';
 import MinusSvg from '/public/svgs/element/minus.svg';
+import { useRouter } from 'next/router';
 
 const Wrapper = styled.div`
   padding: 24px 16px;
@@ -106,6 +107,8 @@ interface ItemFooterProps {
 }
 
 const ItemFooter = ({ price, profileImages }: ItemFooterProps) => {
+  const router = useRouter();
+  
   const [quantity, setQuantity] = useState(1);
   const [isHeartFilled, setIsHeartFilled] = useState(false);
   const [selectedProfiles, setSelectedProfiles] = useState<boolean[]>(() =>
@@ -137,6 +140,21 @@ const ItemFooter = ({ price, profileImages }: ItemFooterProps) => {
       prevSelected.map((isSelected, i) => (i === index ? !isSelected : isSelected))
     );
   };
+
+  const handleAddToCart = () => {
+    toast(
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        장바구니에 상품을 담았습니다.
+        <button onClick={() => router.push('/mymarket/cart')} style={{ background: 'none', border: 'none', color: 'white', textDecoration: 'underline' }}>
+          바로가기
+        </button>
+      </div>
+    );
+  };
+
+  const handleOrderClick = () => {
+    router.push('/item/payments');
+  }
 
   return (
     <>
@@ -180,8 +198,8 @@ const ItemFooter = ({ price, profileImages }: ItemFooterProps) => {
             <span>{quantity}개</span>
             <PlusSvg onClick={handleIncrease} style={{ cursor: 'pointer' }}>+</PlusSvg>
           </QuantityContainer>
-          <BasketButton>장바구니</BasketButton>
-          <BuyButton>주문하기</BuyButton>
+          <BasketButton onClick={handleAddToCart}>장바구니</BasketButton>
+          <BuyButton onClick={handleOrderClick}>주문하기</BuyButton>
         </BottomContainer>
       </Wrapper>
       {/* Custom CSS for toast style */}

--- a/src/pages/category/food.tsx
+++ b/src/pages/category/food.tsx
@@ -8,6 +8,29 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
+interface CartItem {
+  id: number;
+  imageUrl: string;
+  brand: string
+  name: string;
+  price: number;
+  selected: boolean;
+};
+
+const initialItems: CartItem[] = [
+  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
+  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
+  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
+  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
+  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
+  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
+  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
+  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
+];
+
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -72,6 +95,7 @@ const dummyProducts = [
 
 
 export default function FoodPage() {
+  const [items, setItems] = useState<CartItem[]>(initialItems);
   const [category, setCategory] = useState("전체");
   const [products, setProducts] = useState(dummyProducts);
   const filters = [
@@ -104,7 +128,7 @@ export default function FoodPage() {
 
   return (
     <div className="page">
-      <Header title={"사료"} />
+      <Header title={"사료"} itemCount={items.length} />
       <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>

--- a/src/pages/category/goods.tsx
+++ b/src/pages/category/goods.tsx
@@ -8,6 +8,29 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
+interface CartItem {
+  id: number;
+  imageUrl: string;
+  brand: string
+  name: string;
+  price: number;
+  selected: boolean;
+};
+
+const initialItems: CartItem[] = [
+  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
+  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
+  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
+  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
+  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
+  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
+  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
+  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
+];
+
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -71,7 +94,8 @@ const dummyProducts = [
 ];
 
 
-export default function FoodPage() {
+export default function GoodsPage() {
+  const [items, setItems] = useState<CartItem[]>(initialItems);
   const [category, setCategory] = useState("전체");
   const [products, setProducts] = useState(dummyProducts);
   const filters = [
@@ -104,7 +128,7 @@ export default function FoodPage() {
 
   return (
     <div className="page">
-      <Header title={"용품"}/>
+      <Header title={"용품"} itemCount={items.length} />
       <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -4,7 +4,30 @@ import Header from "@/components/header/CategoryHeader";
 import FooterNav from "@/components/navbar/CategoryFooterNav";
 import styled from 'styled-components';
 import Link from "next/link";
+import { useState } from "react";
 
+interface CartItem {
+    id: number;
+    imageUrl: string;
+    brand: string
+    name: string;
+    price: number;
+    selected: boolean;
+};
+
+const initialItems: CartItem[] = [
+    { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
+    { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
+    { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
+    { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
+    { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
+    { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
+    { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
+    { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
+];
 
 interface TitleContainerProps {
     $marginTop?: number;
@@ -61,10 +84,12 @@ const Item = styled(Link)`  /* Link로 Item을 클릭 가능하게 만듦 */
     }
 `;
 
-export default function Home() {
+export default function CategoryPage() {
+    const [items, setItems] = useState<CartItem[]>(initialItems);
+
     return (
         <div className="page">
-            <Header />
+            <Header itemCount={items.length}/>
             <div className="content">
             {/* 강아지 섹션 */}
             <TitleContainer $marginTop={16}>

--- a/src/pages/category/snack.tsx
+++ b/src/pages/category/snack.tsx
@@ -8,6 +8,29 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
+interface CartItem {
+  id: number;
+  imageUrl: string;
+  brand: string
+  name: string;
+  price: number;
+  selected: boolean;
+};
+
+const initialItems: CartItem[] = [
+  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
+  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
+  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
+  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
+  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
+  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
+  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
+  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
+];
+
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -72,6 +95,7 @@ const dummyProducts = [
 
 
 export default function FoodPage() {
+  const [items, setItems] = useState<CartItem[]>(initialItems);
   const [category, setCategory] = useState("전체");
   const [products, setProducts] = useState(dummyProducts);
   const filters = [
@@ -104,7 +128,7 @@ export default function FoodPage() {
 
   return (
     <div className="page">
-      <Header title={"간식"}/>
+      <Header title={"간식"} itemCount={items.length} />
       <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>

--- a/src/pages/item/index.tsx
+++ b/src/pages/item/index.tsx
@@ -1,4 +1,4 @@
-// item/page.tsx
+// item/index.tsx
 
 'use client';
 
@@ -6,7 +6,30 @@ import Header from "@/components/header/ItemHeader";
 import FooterNav from "@/components/navbar/ItemFooter";
 import InfoSection from "@/components/items/ItemInfo";
 import styled from 'styled-components';
-import Link from "next/link";
+import { useState } from "react";
+
+interface CartItem {
+    id: number;
+    imageUrl: string;
+    brand: string
+    name: string;
+    price: number;
+    selected: boolean;
+};
+
+const initialItems: CartItem[] = [
+    { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
+    { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
+    { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
+    { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
+    { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
+    { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
+    { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
+    { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
+    { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
+];
 
 const ImageWrapper = styled.div`
     position: relative;
@@ -33,17 +56,18 @@ const DetailImage = styled.img`
     width: 100%;
 `;
 
-export default function Home() {
+export default function ItemPage() {
+    const [items, setItems] = useState<CartItem[]>(initialItems);
 
     const profileImages = [
         "/images/catdongle.jpeg",
         "/images/gom.jpeg",
         "/images/soogom.jpeg",
-      ];
+    ];
 
     return (
         <div className="page">
-            <Header />
+            <Header itemCount={items.length} />
             <div className="content">
                 <ImageWrapper>
                     <ItemImage
@@ -61,7 +85,7 @@ export default function Home() {
                     상품설명
                 </DetailTitle>
                 <DetailImage src="https://shopping-phinf.pstatic.net/20200521_09_28/2968b9a2-aedf-4eda-84c8-cb09b81dae01/C:UsersuserDesktopb1ac3b5d07c1052752f6e75cb610e13d_092143.jpg"
-                             alt="Product Detail Image"/>
+                    alt="Product Detail Image" />
             </div>
             <FooterNav price={44900} profileImages={profileImages} />
         </div>


### PR DESCRIPTION
## 관련 이슈

- #46 

## 요약 📝

- 카테고리&아이템: 디테일 수정
-  카테고리&아이템: 헤더 장바구니 상품 개수 연동
- 카테고리&아이템: 뒤로가기 버튼 페이지 연결
- 아이템: 주문하기 페이지 연결
- 아이템: 장바구니 버튼 클릭시 토스트 메세지

## 상세 내용 및 스크린샷 🔥

<img src="https://github.com/user-attachments/assets/136ba8be-4456-4c0d-93f1-a7930cd5235e" width="200px" />
<img src="https://github.com/user-attachments/assets/3a96dd44-622a-4424-958d-f3b2a7646258" width="200px" />
<img src="https://github.com/user-attachments/assets/3d2516eb-efaf-45b3-8f18-8857d4f8c445" width="200px" />

## 리뷰어에게 부탁, 유의사항 🙏

- 
