### PR TITLE
[feat] 유저 정보 활용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "sass": "^1.80.4",
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.13",
-        "swiper": "^11.1.14"
+        "swiper": "^11.1.14",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -7741,6 +7742,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "sass": "^1.80.4",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.13",
-    "swiper": "^11.1.14"
+    "swiper": "^11.1.14",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/components/header/CategoryDetailHeader.tsx
+++ b/src/components/header/CategoryDetailHeader.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
 import BackSvg from '/public/svgs/header/back_arrow.svg';
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
+import { useUserStore } from '@/store/user';
 
 const Wrapper = styled.div`
   position: fixed;
@@ -47,12 +48,12 @@ const ItemCountBadge = styled.span`
 
 interface CategoryDetailHeaderProps {
   title: string;
-  itemCount: number;
 }
 
-const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title, itemCount }) => {
+const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title }) => {
   const router = useRouter();
   const history = useRouter();
+  const cartCount = useUserStore((state) => state.cartCount);
 
   const handleBackClick = () => {
     history.back();
@@ -68,7 +69,7 @@ const CategoryDetailHeader: React.FC<CategoryDetailHeaderProps> = ({ title, item
       <Title>{title}</Title>
       <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
           <ShoppingBasketSvg />
-          {<ItemCountBadge>{itemCount}</ItemCountBadge>}
+          {<ItemCountBadge>{cartCount}</ItemCountBadge>}
         </BasketContainer>
     </Wrapper>
   );

--- a/src/components/header/CategoryHeader.tsx
+++ b/src/components/header/CategoryHeader.tsx
@@ -8,6 +8,7 @@ import DogSvg from '/public/svgs/logo/logo_dog.svg';
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useUserStore } from '@/store/user';
 
 const Wrapper = styled.div`
   position: fixed;
@@ -56,12 +57,9 @@ const ItemCountBadge = styled.span`
   font-size: 12px;
 `;
 
-interface CategoryHeaderProps {
-  itemCount: number;
-}
-
-const CategoryHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
+const CategoryHeader = () => {
   const router = useRouter();
+  const cartCount = useUserStore((state) => state.cartCount);
 
   const handleCartClick = () => {
     router.push('/mymarket/cart');
@@ -76,7 +74,7 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
         </LogoContainer>
         <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
           <ShoppingBasketSvg />
-          {<ItemCountBadge>{itemCount}</ItemCountBadge>}
+          {<ItemCountBadge>{cartCount}</ItemCountBadge>}
         </BasketContainer>
       </LogoWrapper>
     </Wrapper>

--- a/src/components/header/ItemHeader.tsx
+++ b/src/components/header/ItemHeader.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import BackSvg from '/public/svgs/header/back_arrow.svg'
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
 import { useRouter } from 'next/router';
+import { useUserStore } from '@/store/user';
 
 const Wrapper = styled.div`
   padding: 14px 16px;
@@ -48,13 +49,10 @@ const ItemCountBadge = styled.span`
   font-size: 12px;
 `;
 
-interface CategoryHeaderProps {
-  itemCount: number;
-}
-
-const ItemHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
+const ItemHeader = () => {
   const router = useRouter();
   const history = useRouter();
+  const cartCount = useUserStore((state) => state.cartCount);
 
   const handleBackClick = () => {
     history.back();
@@ -72,7 +70,7 @@ const ItemHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
         </LogoContainer>
         <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
           <ShoppingBasketSvg />
-          {<ItemCountBadge>{itemCount}</ItemCountBadge>}
+          {<ItemCountBadge>{cartCount}</ItemCountBadge>}
         </BasketContainer>
       </LogoWrapper>
     </Wrapper>

--- a/src/components/header/ItemHeader.tsx
+++ b/src/components/header/ItemHeader.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
 
 const LogoContainer = styled.div`
   display: flex;
-  gap: 2px
+  gap: 2px;
 `;
 
 const LogoWrapper = styled.div`

--- a/src/components/header/PaymentsHeader.tsx
+++ b/src/components/header/PaymentsHeader.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
 import BackSvg from '/public/svgs/header/back_arrow.svg';
 import ShoppingBasketSvg from '/public/svgs/header/black_shoppingbag.svg';
+import { useUserStore } from '@/store/user';
 
 const Wrapper = styled.div`
   position: fixed;
@@ -45,12 +46,9 @@ const ItemCountBadge = styled.span`
   font-size: 12px;
 `;
 
-interface CategoryHeaderProps {
-    itemCount: number;
-}
-
-const PaymentsHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
+const PaymentsHeader = () => {
     const router = useRouter();
+    const cartCount = useUserStore((state) => state.cartCount);
 
     const handleBackClick = () => {
         router.back();
@@ -66,7 +64,7 @@ const PaymentsHeader: React.FC<CategoryHeaderProps> = ({ itemCount }) => {
             <Title>결제하기</Title>
             <BasketContainer onClick={handleCartClick} style={{ cursor: 'pointer' }}>
                 <ShoppingBasketSvg />
-                {<ItemCountBadge>{itemCount}</ItemCountBadge>}
+                {<ItemCountBadge>{cartCount}</ItemCountBadge>}
             </BasketContainer>
         </Wrapper>
     );

--- a/src/components/navbar/CategoryFooterNav.tsx
+++ b/src/components/navbar/CategoryFooterNav.tsx
@@ -9,6 +9,7 @@ import DogHomeSvg from '/public/svgs/navbar/home_icon.svg';
 import BasketSvg from '/public/svgs/navbar/basket_icon.svg';
 import MySvg from '/public/svgs/navbar/user_icon.svg';
 import Link from 'next/link';
+import { useUserStore } from '@/store/user';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -59,6 +60,7 @@ const BoldText = styled.span`
 `;
 
 const CategoryFooterNav = () => {
+  const petId = useUserStore((state) => state.petId);
   return (
     <FooterNavContainer>
       <NavContainer>
@@ -66,7 +68,7 @@ const CategoryFooterNav = () => {
             <HamburgerSvg />
             <BoldText>카테고리</BoldText>
         </IconContainer>
-        <IconContainer href="/mydongle">
+        <IconContainer href={`/mydongle/${petId}`}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/CategoryFooterNav.tsx
+++ b/src/components/navbar/CategoryFooterNav.tsx
@@ -68,7 +68,7 @@ const CategoryFooterNav = () => {
             <HamburgerSvg />
             <BoldText>카테고리</BoldText>
         </IconContainer>
-        <IconContainer href={`/mydongle/${petId}`}>
+        <IconContainer href={petId ? `/mydongle/${petId}` : '/mydongle/add'}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/MainFooterNav.tsx
+++ b/src/components/navbar/MainFooterNav.tsx
@@ -68,7 +68,7 @@ const MainFooterNav = () => {
           <HamburgerSvg />
           <span>카테고리</span>
         </IconContainer>
-        <IconContainer href={`/mydongle/${petId}`}>
+        <IconContainer href={petId ? `/mydongle/${petId}` : '/mydongle/add'}>
           <MyDongleSvg />
           <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/MainFooterNav.tsx
+++ b/src/components/navbar/MainFooterNav.tsx
@@ -9,6 +9,7 @@ import MyDongleSvg from '/public/svgs/navbar/mydongle_icon.svg';
 import DogHomeSvg from '/public/svgs/navbar/home_icon_select.svg';
 import MyMarketSvg from '/public/svgs/navbar/basket_icon.svg';
 import MySvg from '/public/svgs/navbar/user_icon.svg';
+import { useUserStore } from '@/store/user';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -59,6 +60,7 @@ const BoldText = styled.span`
 `;
 
 const MainFooterNav = () => {
+  const petId = useUserStore((state) => state.petId);
   return (
     <FooterNavContainer>
       <NavContainer>
@@ -66,7 +68,7 @@ const MainFooterNav = () => {
           <HamburgerSvg />
           <span>카테고리</span>
         </IconContainer>
-        <IconContainer href="/mydongle">
+        <IconContainer href={`/mydongle/${petId}`}>
           <MyDongleSvg />
           <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/MyDongleFooterNav.tsx
+++ b/src/components/navbar/MyDongleFooterNav.tsx
@@ -68,7 +68,7 @@ const MyDongleFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href={`/mydongle/${petId}`}>
+        <IconContainer href={petId ? `/mydongle/${petId}` : '/mydongle/add'}>
             <MyDongleSvg />
             <BoldText>마이 동글</BoldText>
         </IconContainer>

--- a/src/components/navbar/MyDongleFooterNav.tsx
+++ b/src/components/navbar/MyDongleFooterNav.tsx
@@ -9,6 +9,7 @@ import DogHomeSvg from '/public/svgs/navbar/home_icon.svg';
 import BasketSvg from '/public/svgs/navbar/basket_icon.svg';
 import MySvg from '/public/svgs/navbar/user_icon.svg';
 import Link from 'next/link';
+import { useUserStore } from '@/store/user';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -59,6 +60,7 @@ const BoldText = styled.span`
 `;
 
 const MyDongleFooterNav = () => {
+  const petId = useUserStore((state) => state.petId);
   return (
     <FooterNavContainer>
       <NavContainer>
@@ -66,7 +68,7 @@ const MyDongleFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href="/mydongle">
+        <IconContainer href={`/mydongle/${petId}`}>
             <MyDongleSvg />
             <BoldText>마이 동글</BoldText>
         </IconContainer>

--- a/src/components/navbar/MyMarketFooterNav.tsx
+++ b/src/components/navbar/MyMarketFooterNav.tsx
@@ -9,6 +9,7 @@ import MyDongleSvg from '/public/svgs/navbar/mydongle_icon.svg';
 import DogHomeSvg from '/public/svgs/navbar/home_icon.svg';
 import BasketSvg from '/public/svgs/navbar/basket_icon_select.svg';
 import MySvg from '/public/svgs/navbar/user_icon.svg';
+import { useUserStore } from '@/store/user';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -59,6 +60,7 @@ const BoldText = styled.span`
 `;
 
 const MyMarketFooterNav = () => {
+  const petId = useUserStore((state) => state.petId);
   return (
     <FooterNavContainer>
       <NavContainer>
@@ -66,7 +68,7 @@ const MyMarketFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href="/mydongle">
+        <IconContainer href={`/mydongle/${petId}`}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/MyMarketFooterNav.tsx
+++ b/src/components/navbar/MyMarketFooterNav.tsx
@@ -68,7 +68,7 @@ const MyMarketFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href={`/mydongle/${petId}`}>
+        <IconContainer href={petId ? `/mydongle/${petId}` : '/mydongle/add'}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/UserInfoFooterNav.tsx
+++ b/src/components/navbar/UserInfoFooterNav.tsx
@@ -68,7 +68,7 @@ const UserInfoFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href={`/mydongle/${petId}`}>
+        <IconContainer href={petId ? `/mydongle/${petId}` : '/mydongle/add'}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/components/navbar/UserInfoFooterNav.tsx
+++ b/src/components/navbar/UserInfoFooterNav.tsx
@@ -9,6 +9,7 @@ import DogHomeSvg from '/public/svgs/navbar/home_icon.svg';
 import BasketSvg from '/public/svgs/navbar/basket_icon.svg';
 import MySvg from '/public/svgs/navbar/user_icon_select.svg';
 import Link from 'next/link';
+import { useUserStore } from '@/store/user';
 
 const FooterNavContainer = styled.nav`
   position: fixed;
@@ -59,6 +60,7 @@ const BoldText = styled.span`
 `;
 
 const UserInfoFooterNav = () => {
+  const petId = useUserStore((state) => state.petId);
   return (
     <FooterNavContainer>
       <NavContainer>
@@ -66,7 +68,7 @@ const UserInfoFooterNav = () => {
             <HamburgerSvg />
             <span>카테고리</span>
         </IconContainer>
-        <IconContainer href="/mydongle">
+        <IconContainer href={`/mydongle/${petId}`}>
             <MyDongleSvg />
             <span>마이 동글</span>
         </IconContainer>

--- a/src/pages/category/food.tsx
+++ b/src/pages/category/food.tsx
@@ -168,7 +168,7 @@ export default function FoodPage() {
 
   return (
     <div className="page">
-      <Header title={"사료"} itemCount={items.length} />
+      <Header title={"사료"} />
       <div className="content">
         <Content>
           {categoryOptions.map(option => (

--- a/src/pages/category/food.tsx
+++ b/src/pages/category/food.tsx
@@ -10,29 +10,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-interface CartItem {
-  id: number;
-  imageUrl: string;
-  brand: string;
-  name: string;
-  price: number;
-  selected: boolean;
-};
-
-const initialItems: CartItem[] = [  
-  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -85,7 +62,6 @@ const Item = styled.div<{ $isSelected?: boolean }>`
 `;
 
 export default function FoodPage() {
-  const [items, ] = useState<CartItem[]>(initialItems);
   const router = useRouter();
   const { species = 'dog', sub = '', order = '' } = router.query;
 

--- a/src/pages/category/goods.tsx
+++ b/src/pages/category/goods.tsx
@@ -8,29 +8,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-interface CartItem {
-  id: number;
-  imageUrl: string;
-  brand: string
-  name: string;
-  price: number;
-  selected: boolean;
-};
-
-const initialItems: CartItem[] = [
-  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -95,7 +72,6 @@ const dummyProducts = [
 
 
 export default function GoodsPage() {
-  const [items, ] = useState<CartItem[]>(initialItems);
   const [category, setCategory] = useState("전체");
   const [products, ] = useState(dummyProducts);
   const filters = [

--- a/src/pages/category/goods.tsx
+++ b/src/pages/category/goods.tsx
@@ -128,7 +128,7 @@ export default function GoodsPage() {
 
   return (
     <div className="page">
-      <Header title={"용품"} itemCount={items.length} />
+      <Header title={"용품"} />
       <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -4,30 +4,6 @@ import Header from "@/components/header/CategoryHeader";
 import FooterNav from "@/components/navbar/CategoryFooterNav";
 import styled from 'styled-components';
 import Link from "next/link";
-import { useState } from "react";
-
-interface CartItem {
-    id: number;
-    imageUrl: string;
-    brand: string
-    name: string;
-    price: number;
-    selected: boolean;
-};
-
-const initialItems: CartItem[] = [
-    { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-    { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-    { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-    { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-    { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-    { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-    { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-    { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
 
 interface TitleContainerProps {
     $marginTop?: number;
@@ -85,8 +61,6 @@ const Item = styled(Link)`  /* Link로 Item을 클릭 가능하게 만듦 */
 `;
 
 export default function CategoryPage() {
-    const [items, ] = useState<CartItem[]>(initialItems);
-
     return (
         <div className="page">
             <Header />

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -89,7 +89,7 @@ export default function CategoryPage() {
 
     return (
         <div className="page">
-            <Header itemCount={items.length}/>
+            <Header />
             <div className="content">
             {/* 강아지 섹션 */}
             <TitleContainer $marginTop={16}>

--- a/src/pages/category/snack.tsx
+++ b/src/pages/category/snack.tsx
@@ -8,29 +8,6 @@ import ProductRow from "@/components/items/CategoryItemsRow";
 import SelectBox from "@/components/header/SelectBox";
 import styled from 'styled-components';
 
-interface CartItem {
-  id: number;
-  imageUrl: string;
-  brand: string
-  name: string;
-  price: number;
-  selected: boolean;
-};
-
-const initialItems: CartItem[] = [
-  { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-  { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-  { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-  { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-  { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-  { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-  { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-  { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-  { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
-
 const ProductListContainer = styled.div`
   padding: 16px;
   display: flex;
@@ -95,7 +72,6 @@ const dummyProducts = [
 
 
 export default function FoodPage() {
-  const [items, ] = useState<CartItem[]>(initialItems);
   const [category, setCategory] = useState("전체");
   const [products, ] = useState(dummyProducts);
   const filters = [

--- a/src/pages/category/snack.tsx
+++ b/src/pages/category/snack.tsx
@@ -128,7 +128,7 @@ export default function FoodPage() {
 
   return (
     <div className="page">
-      <Header title={"간식"} itemCount={items.length} />
+      <Header title={"간식"} />
       <div className="content">
         {/* 카테고리 선택 표시 */}
         <Content>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -8,6 +8,7 @@ import Banner from "@/components/main/Banner";
 import MainItem from "@/components/items/MainItem";
 import { UserResponse } from '@/services/users/users.type';
 import { getUserInfo } from '@/services/users/users';
+import { useUserStore } from '@/store/user';
 
 interface Item {
   itemId: number;
@@ -84,25 +85,26 @@ type MainCategory = keyof (typeof subCategories)["dog"];
 type Species = "dog" | "cat";
 
 export default function PetHome() {
-  const [itemCount, ] = useState(0);
   const [species, setSpecies] = useState<Species>("dog");
   const [mainCategory, setMainCategory] = useState<MainCategory | null>(null);
   const [products, setProducts] = useState<{ [key: string]: Item[] }>({});
-  const [userData, setUserData] = useState<UserResponse>();
+  const setPetId = useUserStore((state) => state.setPetId);
+  const setCartCount = useUserStore((state) => state.setCartCount);
+  const cartCount = useUserStore((state) => state.cartCount);
 
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        const data = await getUserInfo();
-        console.log(data);
-        setUserData(data);
+        const data: UserResponse = await getUserInfo();
+        setPetId(data.pets.length > 0 ? data.pets[0].petId : null);
+        setCartCount(data.carts.length);
       } catch (error) {
         console.error("Failed to fetch user data", error);
       }
     };
 
     fetchUserData();
-  }, []);
+  }, [setPetId, setCartCount]);
 
   useEffect(() => {
     const fetchProducts = async () => {
@@ -231,7 +233,7 @@ export default function PetHome() {
   return (
     <div className="page">
       <MainHeader
-        itemCount={itemCount}
+        itemCount={cartCount}
         species={species}
         onSpeciesChange={(newSpecies) => {
           setSpecies(newSpecies as Species);

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -6,6 +6,8 @@ import MainHeader from "@/components/header/MainHeader";
 import FooterNav from "@/components/navbar/MainFooterNav";
 import Banner from "@/components/main/Banner";
 import MainItem from "@/components/items/MainItem";
+import { UserResponse } from '@/services/users/users.type';
+import { getUserInfo } from '@/services/users/users';
 
 interface Item {
   itemId: number;
@@ -86,6 +88,21 @@ export default function PetHome() {
   const [species, setSpecies] = useState<Species>("dog");
   const [mainCategory, setMainCategory] = useState<MainCategory | null>(null);
   const [products, setProducts] = useState<{ [key: string]: Item[] }>({});
+  const [userData, setUserData] = useState<UserResponse>();
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const data = await getUserInfo();
+        console.log(data);
+        setUserData(data);
+      } catch (error) {
+        console.error("Failed to fetch user data", error);
+      }
+    };
+
+    fetchUserData();
+  }, []);
 
   useEffect(() => {
     const fetchProducts = async () => {

--- a/src/pages/item/[id]/index.tsx
+++ b/src/pages/item/[id]/index.tsx
@@ -135,7 +135,7 @@ export default function ItemPage() {
 
     return (
         <div className="page">
-            <Header itemCount={items.length} />
+            <Header />
             <div className="content">
                 <ImageWrapper>
                     <ItemImage

--- a/src/pages/item/[id]/index.tsx
+++ b/src/pages/item/[id]/index.tsx
@@ -11,29 +11,6 @@ import { removeHtmlTags } from "@/utils/removeHtmlTags";
 import FallbackComponent from "@/components/common/Fallback";
 import LoadingComponent from "@/components/common/Loading";
 
-interface CartItem {
-    id: number;
-    imageUrl: string;
-    brand: string
-    name: string;
-    price: number;
-    selected: boolean;
-};
-
-const initialItems: CartItem[] = [
-    { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-    { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-    { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-    { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-    { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-    { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-    { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-    { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
-
 const categoryMap: { [key: string]: string } = {
     food: "사료",
     snack: "간식",
@@ -93,8 +70,6 @@ interface Item {
   }
 
 export default function ItemPage() {
-    const [items, ] = useState<CartItem[]>(initialItems);
-
     const profileImages = [
         "/images/catdongle.jpeg",
         "/images/gom.jpeg",

--- a/src/pages/mydongle/add.tsx
+++ b/src/pages/mydongle/add.tsx
@@ -323,7 +323,7 @@ export default function MyDongleAddPage() {
 
   return (
     <div className="page">
-      <MyDongleHeader itemCount={5} />
+      <MyDongleHeader />
       <ToastContainer
         position="top-center"
         style={{ marginTop: "32px", boxSizing: "border-box" }}

--- a/src/pages/mydongle/index.tsx
+++ b/src/pages/mydongle/index.tsx
@@ -145,7 +145,7 @@ export default function MyDonglePage() {
 
   return (
     <div className="page">
-      <Header itemCount={items.length} />
+      <Header />
       <div className="mydonglecontent">
         <MyDongleHeader />
         <PetsPortWrapper>

--- a/src/pages/mymarket/cart.tsx
+++ b/src/pages/mymarket/cart.tsx
@@ -225,7 +225,7 @@ export default function CartPage() {
 
     return (
         <div className="page">
-            <CartHeader itemCount={cartItems.length} />
+            <CartHeader />
             <div className='content' style={{ paddingBottom: '163px' }}>
                 <TabMenu />
                 {cartItems.length === 0 ? (

--- a/src/pages/mymarket/history.tsx
+++ b/src/pages/mymarket/history.tsx
@@ -147,7 +147,7 @@ function formatDeliveryDate(dateStr: string): string {
 }
 
 export default function HistoryPage() {
-  const [itemCount, setItemCount] = useState(0);
+  const [, setItemCount] = useState(0);
   const [cartItems] = useState(initialCartItems);
   const [orders, setOrders] = useState<Order[]>([]); // 빈 배열로 초기화
 

--- a/src/pages/mymarket/history.tsx
+++ b/src/pages/mymarket/history.tsx
@@ -186,7 +186,7 @@ export default function HistoryPage() {
 
   return (
     <div className="page">
-      <HistoryHeader itemCount={itemCount} />
+      <HistoryHeader />
       <div className='content'>
         <TabMenu />
         {orders && orders.length > 0 ? (

--- a/src/pages/mymarket/wishlist.tsx
+++ b/src/pages/mymarket/wishlist.tsx
@@ -127,7 +127,7 @@ const DongleMarketButton = styled(Link)`
 `;
 
 export default function WishlistPage() {
-    const [itemCount, setItemCount] = useState(0);
+    const [, setItemCount] = useState(0);
 
     useEffect(() => {
         const updateItemCount = () => {

--- a/src/pages/mymarket/wishlist.tsx
+++ b/src/pages/mymarket/wishlist.tsx
@@ -142,8 +142,8 @@ export default function WishlistPage() {
 
 
     return (
-        <Page className="page">
-            <WishlistHeader itemCount={itemCount} />
+        <div className="page">
+            <WishlistHeader />
             <div className='content'>
                 <TabMenu />
                 <BlurredBackground>

--- a/src/pages/mymarket/wishlist.tsx
+++ b/src/pages/mymarket/wishlist.tsx
@@ -142,7 +142,7 @@ export default function WishlistPage() {
 
 
     return (
-        <div className="page">
+        <Page className="page">
             <WishlistHeader />
             <div className='content'>
                 <TabMenu />

--- a/src/pages/payments/index.tsx
+++ b/src/pages/payments/index.tsx
@@ -197,7 +197,7 @@ export default function PaymentsPage() {
 
     return (
         <div className="page">
-            <PaymentsHeader itemCount={cartItems.length} />
+            <PaymentsHeader />
             <div className='content'>
 
                 {/** 주문자 정보 */}

--- a/src/pages/payments/success.tsx
+++ b/src/pages/payments/success.tsx
@@ -64,7 +64,7 @@ export default function SuccessPage() {
 
   return (
     <div className="page">
-      <PaymentsHeader itemCount={5} />
+      <PaymentsHeader />
       <div className='content'>
         <ConfirmTextContainer>
           <h2>주문이 완료되었어요.</h2>

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -178,7 +178,7 @@ export default function ProfileEditPage() {
 
     return (
         <div className="page">
-            <UserHeader itemCount={itemCount} />
+            <UserHeader />
             <ToastContainer
                 position="top-center"
                 style={{ marginTop: '32px', boxSizing: 'border-box' }}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -5,32 +5,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import UserHeader from '@/components/header/CategoryHeader';
 import UserInfoFooterNav from '@/components/navbar/UserInfoFooterNav';
-import CartItem from '@/components/items/CartItem';
 import PassPort from '@/components/items/PassPort';
 import LogoutModal from '@/components/items/LogoutModal';
-
-interface CartItem {
-    id: number;
-    imageUrl: string;
-    brand: string
-    name: string;
-    price: number;
-    selected: boolean;
-};
-
-const initialItems: CartItem[] = [
-    { id: 1, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: true },
-    { id: 2, imageUrl: '/images/Baek.png', brand: '아디다스', name: '어얼얽--', price: 34000, selected: true },
-    { id: 3, imageUrl: '/images/An.png', brand: '아디다스', name: '고기가 이븐하게 익지 않아써여', price: 34000, selected: true },
-    { id: 4, imageUrl: '/images/An.png', brand: '아디다스', name: '보류입니다.', price: 34000, selected: true },
-    { id: 5, imageUrl: '/images/An.png', brand: '아디다스', name: '저는 채소의 익힘 정도를 굉장히 중요시 여기거덩여', price: 34000, selected: true },
-    { id: 6, imageUrl: '/images/Baek.png', brand: '아디다스', name: '이거 빠쓰자나~ 어허~ 재밌네 이거ㅎㅎ', price: 34000, selected: true },
-    { id: 7, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 8, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 9, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스', price: 34000, selected: false },
-    { id: 10, imageUrl: '/images/product1.png', brand: '아디다스', name: '도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스도치빌 리더스', price: 34000, selected: false },
-    { id: 11, imageUrl: '/images/Son&Jeon.png', brand: '아디다스', name: '왜저뤠ㅞㅞ~~', price: 34000, selected: false }
-];
 
 const Wrapper = styled.div`
     display: flex;
@@ -61,7 +37,6 @@ const LogOutButton = styled.div`
 `;
 
 export default function ProfilePage() {
-    const [items, ] = useState<CartItem[]>(initialItems);
     const [showModal, setShowModal] = useState(false);
   
     const handleLogoutClick = () => {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -80,7 +80,7 @@ export default function ProfilePage() {
 
     return (
         <div className="page">
-            <UserHeader itemCount={items.length} />
+            <UserHeader />
             <div className='content'>
                 <Wrapper>
                     <MyProfileTitle>IDENTIFICATION CARD</MyProfileTitle>

--- a/src/services/carts/carts.type.ts
+++ b/src/services/carts/carts.type.ts
@@ -1,0 +1,4 @@
+export interface CartType {
+  cartId: number;
+  itemCount: number;
+}

--- a/src/services/users/users.type.ts
+++ b/src/services/users/users.type.ts
@@ -1,3 +1,6 @@
+import { CartType } from "../carts/carts.type";
+import { PetType } from "../pets/pets.type";
+
 export interface UserResponse {
   userId: number;
   userName: string;
@@ -8,4 +11,6 @@ export interface UserResponse {
   phoneNumber?: string;
   createdAt: Date;
   updatedAt: Date;
+  pets: PetType[];
+  carts: CartType[];
 }

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface UserAtomType {
+  petId: number | null;
+  cartCount: number;
+  setPetId: (petId: number | null) => void;
+  setCartCount: (count: number) => void;
+}
+
+export const useUserStore = create<UserAtomType>((set) => ({
+  petId: null,
+  cartCount: 0,
+  setPetId: (petId: number | null) => set({ petId }),
+  setCartCount: (cartCount: number) => set({ cartCount })  
+}))


### PR DESCRIPTION
## 관련 이슈

- #62

## 요약 📝

- 유저 정보 활용하기!

## 상세 내용 및 스크린샷 🔥

- 유저 정보의 장바구니갯수와 펫 정보를 각각 헤더, 푸터에 활용
- 헤더의 itemCount props를 지우고, 전역상태로 불러옵니다.
- 푸터에서도 전역상태로 petId를 가져옵니다.

## 리뷰어에게 부탁, 유의사항 🙏

- 
